### PR TITLE
Disable the original speaking ring

### DIFF
--- a/AnimatedSpeakingRings.theme.css
+++ b/AnimatedSpeakingRings.theme.css
@@ -30,3 +30,8 @@
   --gradientangle: 45deg;
   --dmvoicebgcolor: #18191c
 }
+
+.avatarSpeaking-2IGMRN {  
+    -webkit-box-shadow: inset 0 0 0 2px hsl(139,calc(var(--saturation-factor, 1)*47.3%),43.9%),inset 0 0 0 3px var(--background-secondary);
+    -webkit-box-shadow: none !important;
+}


### PR DESCRIPTION
Themes like MinimalCord will keep their speaking ring active even when this theme is enabled.  
These few lines make sure that doesn't happen.  

- **Without these `lines` and MinimalCord enabled:**
![image](https://user-images.githubusercontent.com/37036318/121529789-0738bd80-c9fd-11eb-8394-6a55b15755c3.png)
- **With these `lines` and MinimalCord enabled:**
![image](https://user-images.githubusercontent.com/37036318/121529907-28011300-c9fd-11eb-9086-cd5be061601d.png)

